### PR TITLE
Spider fixes

### DIFF
--- a/kingfisher_scrapy/spiders/afghanistan_records.py
+++ b/kingfisher_scrapy/spiders/afghanistan_records.py
@@ -13,7 +13,8 @@ class AfghanistanRecords(scrapy.Spider):
         if hasattr(self, 'sample') and self.sample == 'true':
             files_urls = [files_urls[0]]
 
-        yield {
-            'file_urls': files_urls,
-            'data_type': 'record'
-        }
+        for file_url in files_urls:
+            yield {
+                'file_urls': [file_url],
+                'data_type': 'record'
+            }

--- a/kingfisher_scrapy/spiders/afghanistan_releases.py
+++ b/kingfisher_scrapy/spiders/afghanistan_releases.py
@@ -11,7 +11,10 @@ class AfghanistanReleases(scrapy.Spider):
     def parse(self, response):
         urls = json.loads(response.body)
 
-        if self.sample:
+        print(urls)
+
+        if hasattr(self, 'sample') and self.sample == 'true':
+            # Only get one date
             urls = [urls[0]]
 
         for url in urls:
@@ -19,8 +22,14 @@ class AfghanistanReleases(scrapy.Spider):
 
     def parse_release_urls(self, response):
         release_urls = json.loads(response.body)
-        if len(release_urls) > 0:
-            yield {
-                "file_urls": release_urls,
-                "data_type": "release"
-            }
+            
+        if len(release_urls) > 0: # Some dates have no releases
+            if hasattr(self, 'sample') and self.sample == 'true':
+                # Only get one release
+                release_urls = [release_urls[0]]
+
+            for release_url in release_urls:
+                yield {
+                    "file_urls": [release_url],
+                    "data_type": "release"
+                }

--- a/kingfisher_scrapy/spiders/afghanistan_releases.py
+++ b/kingfisher_scrapy/spiders/afghanistan_releases.py
@@ -11,8 +11,6 @@ class AfghanistanReleases(scrapy.Spider):
     def parse(self, response):
         urls = json.loads(response.body)
 
-        print(urls)
-
         if hasattr(self, 'sample') and self.sample == 'true':
             # Only get one date
             urls = [urls[0]]


### PR DESCRIPTION
Emit file URLs one by one instead of in chunks so requests are none-blocking