### PR TITLE
Use requests for API post, log failures.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scrapy >= 1.5.1
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 scrapy >= 1.5.1
-requests
+requests >= 2.21.0


### PR DESCRIPTION
This PR goes back to using `requests` for the API posting. 

This is a stop-gap to meet the immediate need of getting data into the database ASAP in the crawling process, as with using Scrapy's' inbuilt Request the POSTs get added to the queue and don't start until about half way through the crawl.

We need more work to figure out how to change how Scrapy's scheduler prioritises requests to fix this for the long term.