### PR TITLE
Modify Canada Buy And Sell Spider

### DIFF
--- a/kingfisher_scrapy/spiders/canada_buyandsell.py
+++ b/kingfisher_scrapy/spiders/canada_buyandsell.py
@@ -3,23 +3,20 @@ import scrapy
 
 class CanadaBuyAndSell(scrapy.Spider):
     name = "canada_buyandsell"
+    start_urls = ['https://buyandsell.gc.ca']
 
-    def start_requests(self):
+    def parse(self, response):
         urls = [
             'https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-13-14.json',
             'https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-14-15.json',
             'https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-15-16.json',
             'https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-16-17.json',
         ]
-        
         if hasattr(self, 'sample') and self.sample == 'true':
-            yield scrapy.Request(urls[0])
-        else:
-            for url in urls:
-                yield scrapy.Request(url)
+            urls = ['https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-13-14.json']
 
-    def parse(self, response):
-        yield {
-            "file_urls": [response.url], 
-            "data_type": "release_package"
-        }
+        for url in urls:
+            yield {
+                "file_urls": [url],
+                "data_type": "release_package"
+            }


### PR DESCRIPTION
Change the spider to put all the urls to download in the parse method
instead of the start_requests method because with this way the url is
requested twice, one for the spider and then again for the file download
pipeline