### PR TITLE
Send files as full path to API, if optional flag set

### DIFF
--- a/docs/use-scrapyd.rst
+++ b/docs/use-scrapyd.rst
@@ -80,7 +80,7 @@ Output - Kingfisher Process
 
 In order to use this, you must also set up the Disk output.
 
-In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline`` and that the 2 API variables are set to load from the environment. For example:
+In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline`` and that the 3 API variables are set to load from the environment. For example:
 
 .. code-block:: python
 
@@ -91,6 +91,7 @@ In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline``
 
     KINGFISHER_API_URI = os.environ.get('KINGFISHER_API_URI')
     KINGFISHER_API_KEY = os.environ.get('KINGFISHER_API_KEY')
+    KINGFISHER_API_LOCAL_DIRECTORY = os.environ.get('KINGFISHER_API_LOCAL_DIRECTORY')
 
 
 The ``kingfisher-process`` API endpoint variables are currently accessed from the scrapyd environment. To configure:

--- a/docs/use-standalone.rst
+++ b/docs/use-standalone.rst
@@ -52,7 +52,7 @@ Output - Kingfisher Process
 
 In order to use this, you must also set up the Disk output.
 
-In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline`` and that the 2 API variables are set to load from the environment. For example:
+In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline`` and that the 3 API variables are set to load from the environment. For example:
 
 .. code-block:: python
 
@@ -63,6 +63,7 @@ In settings.py, make sure ``ITEM_PIPELINES`` includes ``KingfisherPostPipeline``
 
     KINGFISHER_API_URI = os.environ.get('KINGFISHER_API_URI')
     KINGFISHER_API_KEY = os.environ.get('KINGFISHER_API_KEY')
+    KINGFISHER_API_LOCAL_DIRECTORY = os.environ.get('KINGFISHER_API_LOCAL_DIRECTORY')
 
 
 The ``kingfisher-process`` API endpoint variables are currently accessed from the scraper's environment. To configure:

--- a/env.sh.tmpl
+++ b/env.sh.tmpl
@@ -4,3 +4,16 @@
 export KINGFISHER_API_URI=https://kingfisher.example
 
 export KINGFISHER_API_KEY=api-key-here
+
+# Only set KINGFISHER_API_LOCAL_DIRECTORY if the directory the data files are saved in is accessible from the KingFisher Process server.
+# Set the directory the server should look in to get the data files.
+# So this should match up with the FILES_STORE value
+#
+# export KINGFISHER_API_LOCAL_DIRECTORY=/data
+#
+# eg
+# A machine has Scrape installed in /var/lib/kingfisher-scrape/ and the FILES_STORE is just "data"
+# The same machine has Process installed, and the user that runs the Process web server can read all the data files.
+# Set KINGFISHER_API_LOCAL_DIRECTORY to /var/lib/kingfisher-scrape/data/
+
+

--- a/kingfisher_scrapy/settings.py
+++ b/kingfisher_scrapy/settings.py
@@ -77,6 +77,7 @@ FILES_STORE = 'data'
 
 KINGFISHER_API_URI = os.environ.get('KINGFISHER_API_URI')
 KINGFISHER_API_KEY = os.environ.get('KINGFISHER_API_KEY')
+KINGFISHER_API_LOCAL_DIRECTORY = os.environ.get('KINGFISHER_API_LOCAL_DIRECTORY')
 
 # This is used for some legacy environment variables - not needed for new installs
 if not KINGFISHER_API_URI and os.environ.get('KINGFISHER_API_FILE_URI'):


### PR DESCRIPTION
This makes the HTTP request much smaller, hence making it faster, less memory use, and hopefully less likely to have random errors.