### PR TITLE
Add indonesia scraper

### DIFF
--- a/docs/sources.rst
+++ b/docs/sources.rst
@@ -10,6 +10,7 @@ These sources are available as Scrapy spiders:
   *  canada_buyandsell
   *  canada_montreal
   *  colombia - you can pass the additional `page` parameter to this scraper, to indicate what page to start on.
+  *  indonesia_bandung
   *  moldova
   *  uganda
   *  uruguay
@@ -54,7 +55,6 @@ These sources are available as sources in the old system:
   *  digiwhist_switzerland
   *  digiwhist_united_kingdom
   *  honduras_cost
-  *  indonesia_bandung
   *  mexico_administracion_publica_federal
   *  mexico_cdmx
   *  mexico_grupo_aeroporto

--- a/kingfisher_scrapy/spiders/indonesia_bandung.py
+++ b/kingfisher_scrapy/spiders/indonesia_bandung.py
@@ -1,0 +1,53 @@
+import json
+
+import datetime
+import scrapy
+
+from kingfisher_scrapy.base_spider import BaseSpider
+
+
+class IndonesiaBandung(BaseSpider):
+    name = 'indonesia_bandung'
+    custom_settings = {
+        'ITEM_PIPELINES': {
+            'kingfisher_scrapy.pipelines.KingfisherPostPipeline': 400
+        },
+        'HTTPERROR_ALLOW_ALL': True,
+    }
+    base_url = 'https://birms.bandung.go.id/api/packages/year/{}?page={}'
+
+    def start_requests(self):
+        yield scrapy.Request(
+            url=self.base_url.format(2013, 1),
+            meta={'kf_filename': 'page1.json'}
+        )
+
+    def parse(self, response):
+
+        if response.status == 200:
+
+            self.save_response_to_disk(response, response.request.meta['kf_filename'])
+            yield {
+                'success': True,
+                'file_name': response.request.meta['kf_filename'],
+                "data_type": "release_package",
+                "url": response.request.url,
+            }
+
+            if not self.is_sample() and response.request.meta['kf_filename'] == 'page1.json':
+                json_data = json.loads(response.body_as_unicode())
+                current_year = datetime.datetime.now().year + 1
+                for year in range(2013, current_year):
+                    last_page = json_data['last_page']
+                    for page in range(1, last_page + 1):
+                        yield scrapy.Request(
+                            url=self.base_url.format(year, page),
+                            meta={'kf_filename': 'year{}page{}.json'.format(year, page)}
+                        )
+        else:
+            yield {
+                'success': False,
+                'file_name': response.request.meta['kf_filename'],
+                "url": response.request.url,
+                "errors": {"http_code": response.status}
+            }


### PR DESCRIPTION
Ok, so that service returns a list of releases, no release_package and currently none of our models support that https://kingfisher-process.readthedocs.io/en/latest/data-model.html#data-types-for-files

And the old url https://birms.bandung.go.id/api/packages/year/2013 it is not working anymore either, closing and marking as blocked