### PR TITLE
Write out more info to disk - this is so when we try and restore files later, we have the info

### DIFF
--- a/kingfisher_scrapy/base_spider.py
+++ b/kingfisher_scrapy/base_spider.py
@@ -94,7 +94,7 @@ def _generic_get_local_file_path_including_filestore(called_on_class, filename):
     )
 
 
-def _generic_scrapy_save_response_to_disk(called_on_class, response, filename, is_response=True):
+def _generic_scrapy_save_response_to_disk(called_on_class, response, filename, is_response=True, data_type=None, encoding='utf8'):
 
     source_name_with_sample = called_on_class.name + ('_sample' if called_on_class.is_sample() else '')
     directory = os.path.join(
@@ -109,6 +109,21 @@ def _generic_scrapy_save_response_to_disk(called_on_class, response, filename, i
             f.write(response.body)
         else:
             f.write(response)
+
+    with open(os.path.join(directory, filename + '.fileinfo'), 'w') as f:
+        f.write(json.dumps({
+            'url': response.request.url,
+            'data_type': data_type,
+            'encoding': encoding,
+        }))
+
+    return {
+        'success': True,
+        'file_name': filename,
+        "data_type": data_type,
+        "url": response.request.url,
+        'encoding': encoding,
+    }
 
 # Now we have our own base spiders (that use our generic functions)
 
@@ -140,8 +155,8 @@ class BaseSpider(scrapy.Spider):
     def get_local_file_path_excluding_filestore(self, filename):
         return _generic_get_local_file_path_excluding_filestore(self, filename)
 
-    def save_response_to_disk(self, response, filename, is_response=True):
-        return _generic_scrapy_save_response_to_disk(self, response, filename, is_response)
+    def save_response_to_disk(self, response, filename, is_response=True, data_type=None, encoding='utf-8'):
+        return _generic_scrapy_save_response_to_disk(self, response, filename, is_response=is_response, data_type=data_type, encoding=encoding)
 
 
 class BaseXMLFeedSpider(scrapy.spiders.XMLFeedSpider):
@@ -171,5 +186,5 @@ class BaseXMLFeedSpider(scrapy.spiders.XMLFeedSpider):
     def get_local_file_path_excluding_filestore(self, filename):
         return _generic_get_local_file_path_excluding_filestore(self, filename)
 
-    def save_response_to_disk(self, response, filename):
-        return _generic_scrapy_save_response_to_disk(self, response, filename)
+    def save_response_to_disk(self, response, filename, is_response=True, data_type=None, encoding='utf-8'):
+        return _generic_scrapy_save_response_to_disk(self, response, filename, is_response=is_response, data_type=data_type, encoding=encoding)

--- a/kingfisher_scrapy/pipelines.py
+++ b/kingfisher_scrapy/pipelines.py
@@ -248,7 +248,7 @@ class KingfisherPostPipeline(object):
                 'file_name': item['file_name'],
                 'url': item['url'],
                 'data_type': item['data_type'],
-                # TODO add encoding
+                'encoding': item.get('encoding', 'utf-8'),
             }
 
             if hasattr(spider, 'note') and spider.note:

--- a/kingfisher_scrapy/spiders/afghanistan_records.py
+++ b/kingfisher_scrapy/spiders/afghanistan_records.py
@@ -48,13 +48,8 @@ class AfghanistanRecords(BaseSpider):
     def parse_record(self, response):
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "record",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="record")
+
         elif response.status == 429:
             self.crawler.engine.pause()
             time.sleep(600)  # 10 minutes

--- a/kingfisher_scrapy/spiders/afghanistan_releases.py
+++ b/kingfisher_scrapy/spiders/afghanistan_releases.py
@@ -79,13 +79,8 @@ class AfghanistanReleases(BaseSpider):
     def parse_release(self, response):
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release")
+
         elif response.status == 429:
             self.crawler.engine.pause()
             time.sleep(600)  # 10 minutes

--- a/kingfisher_scrapy/spiders/armenia.py
+++ b/kingfisher_scrapy/spiders/armenia.py
@@ -24,13 +24,7 @@ class Armenia(BaseSpider):
     def parse(self, response):
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
 
             json_data = json.loads(response.body_as_unicode())
             if not (hasattr(self, 'sample') and self.sample == 'true'):

--- a/kingfisher_scrapy/spiders/australia.py
+++ b/kingfisher_scrapy/spiders/australia.py
@@ -38,13 +38,7 @@ class Australia(BaseSpider):
 
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                'data_type': 'release_package',
-                'url': response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
 
             json_data = json.loads(response.body_as_unicode())
             if not self.is_sample():

--- a/kingfisher_scrapy/spiders/australia_nsw.py
+++ b/kingfisher_scrapy/spiders/australia_nsw.py
@@ -74,13 +74,7 @@ class AustraliaNSW(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
 
         else:
             yield {

--- a/kingfisher_scrapy/spiders/buenos_aires.py
+++ b/kingfisher_scrapy/spiders/buenos_aires.py
@@ -38,13 +38,7 @@ class BuenosAires(BaseSpider):
             else:
                 zip_file = ZipFile(BytesIO(response.body))
                 data = zip_file.open('bsas_release.json').read()
-                self.save_response_to_disk(data, response.request.meta['kf_filename'], is_response=False)
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'release_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(data, response.request.meta['kf_filename'], is_response=False, data_type='release_package')
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/canada_buyandsell.py
+++ b/kingfisher_scrapy/spiders/canada_buyandsell.py
@@ -35,13 +35,7 @@ class CanadaBuyAndSell(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/chile_compra_records.py
+++ b/kingfisher_scrapy/spiders/chile_compra_records.py
@@ -58,13 +58,7 @@ class ChileCompraRecords(BaseSpider):
                     )
 
             else:
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'record_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='record_package')
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/chile_compra_releases.py
+++ b/kingfisher_scrapy/spiders/chile_compra_releases.py
@@ -53,13 +53,7 @@ class ChileCompraReleases(BaseSpider):
                                 meta={'kf_filename': 'data-%s-%s.json' % (data_item['Codigo'], name)}
                             )
             else:
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'release_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/colombia.py
+++ b/kingfisher_scrapy/spiders/colombia.py
@@ -42,13 +42,7 @@ class Colombia(BaseSpider):
 
             elif response.status == 200:
 
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    "data_type": "release_package",
-                    "url": response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
 
                 json_data = json.loads(response.body_as_unicode())
                 if not self.is_sample():

--- a/kingfisher_scrapy/spiders/dhangadhi.py
+++ b/kingfisher_scrapy/spiders/dhangadhi.py
@@ -26,13 +26,7 @@ class Dhangadhi(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
         else:
 
             yield {

--- a/kingfisher_scrapy/spiders/georgia_records.py
+++ b/kingfisher_scrapy/spiders/georgia_records.py
@@ -24,13 +24,7 @@ class GeorgiaRecords(BaseSpider):
     def parse(self, response):
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "record_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="record_package")
 
             json_data = json.loads(response.body_as_unicode())
             if not (hasattr(self, 'sample') and self.sample == 'true'):

--- a/kingfisher_scrapy/spiders/georgia_releases.py
+++ b/kingfisher_scrapy/spiders/georgia_releases.py
@@ -24,13 +24,7 @@ class GeorgiaReleases(BaseSpider):
     def parse(self, response):
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_package")
 
             json_data = json.loads(response.body_as_unicode())
             if not (hasattr(self, 'sample') and self.sample == 'true'):

--- a/kingfisher_scrapy/spiders/honduras_cost.py
+++ b/kingfisher_scrapy/spiders/honduras_cost.py
@@ -20,13 +20,7 @@ class HondurasCoST(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                'data_type': 'record_package',
-                'url': response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="record_package")
 
         else:
             yield {

--- a/kingfisher_scrapy/spiders/honduras_oncae.py
+++ b/kingfisher_scrapy/spiders/honduras_oncae.py
@@ -37,13 +37,7 @@ class HondurasONCAE(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                'data_type': 'release_package',
-                'url': response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
 
         else:
             yield {

--- a/kingfisher_scrapy/spiders/indonesia_bandung.py
+++ b/kingfisher_scrapy/spiders/indonesia_bandung.py
@@ -30,13 +30,8 @@ class IndonesiaBandung(BaseSpider):
             json_data = json.loads(response.body_as_unicode())
             if len(json_data) == 0:
                 return
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_list",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type="release_list")
+
             if not self.is_sample():
                 last_id = json_data[len(json_data)-1]['_id']
                 yield scrapy.Request(

--- a/kingfisher_scrapy/spiders/mexico_grupo_aeroporto.py
+++ b/kingfisher_scrapy/spiders/mexico_grupo_aeroporto.py
@@ -20,13 +20,8 @@ class MexicoGrupoAeroporto(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                'data_type': 'release_package',
-                'url': response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
+
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/paraguay_dncp_records.py
+++ b/kingfisher_scrapy/spiders/paraguay_dncp_records.py
@@ -30,13 +30,8 @@ class ParaguayDNCPRecords(ParaguayDNCPBaseSpider):
                         dont_filter=True
                     )
             else:
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'record_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='record_package')
+
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/paraguay_dncp_releases.py
+++ b/kingfisher_scrapy/spiders/paraguay_dncp_releases.py
@@ -45,13 +45,7 @@ class ParaguayDNCPReleases(ParaguayDNCPBaseSpider):
                         dont_filter=True
                     )
             else:
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'release_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/paraguay_hacienda.py
+++ b/kingfisher_scrapy/spiders/paraguay_hacienda.py
@@ -76,13 +76,8 @@ class ParaguayHacienda(BaseSpider):
                             dont_filter=True
                         )
             else:
-                self.save_response_to_disk(response, response.request.meta['kf_filename'])
-                yield {
-                    'success': True,
-                    'file_name': response.request.meta['kf_filename'],
-                    'data_type': 'release_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
+
         else:
             yield {
                 'success': False,

--- a/kingfisher_scrapy/spiders/test_fail.py
+++ b/kingfisher_scrapy/spiders/test_fail.py
@@ -37,13 +37,8 @@ class TestFail(BaseSpider):
 
     def parse(self, response):
         if response.status == 200:
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                "data_type": "release_package",
-                "url": response.request.url,
-            }
+            yield self.save_response_to_disk(response, response.request.meta['kf_filename'], data_type='release_package')
+
         else:
 
             yield {

--- a/kingfisher_scrapy/spiders/uk_contracts_finder.py
+++ b/kingfisher_scrapy/spiders/uk_contracts_finder.py
@@ -25,14 +25,12 @@ class UKContractsFinder(BaseSpider):
 
         if response.status == 200:
 
-            self.save_response_to_disk(response, response.request.meta['kf_filename'])
-            yield {
-                'success': True,
-                'file_name': response.request.meta['kf_filename'],
-                'data_type': 'release_package_list_in_results',
-                'url': response.request.url,
-                'encoding': 'ISO-8859-1',
-            }
+            yield self.save_response_to_disk(
+                response,
+                response.request.meta['kf_filename'],
+                data_type='release_package_list_in_results',
+                encoding='ISO-8859-1'
+            )
 
             if not self.is_sample() and response.request.meta['kf_filename'] == 'page1.json':
                 json_data = json.loads(response.body_as_unicode())

--- a/kingfisher_scrapy/spiders/uruguay_historical.py
+++ b/kingfisher_scrapy/spiders/uruguay_historical.py
@@ -37,13 +37,8 @@ class UruguayHistorical(BaseSpider):
             zip_files = ZipFile(BytesIO(response.body))
             for finfo in zip_files.infolist():
                 data = zip_files.open(finfo.filename).read()
-                self.save_response_to_disk(data, finfo.filename, is_response=False)
-                yield {
-                    'success': True,
-                    'file_name': finfo.filename,
-                    'data_type': 'release_package',
-                    'url': response.request.url,
-                }
+                yield self.save_response_to_disk(data, finfo.filename, is_response=False, data_type='release_package')
+
         else:
             yield {
                 'success': False,


### PR DESCRIPTION
* Save the note attached to this scrape.
* Also basic scrape variables, in case we can't get them from the folder.
* And save a marker at the end, so we know if the run ended.
* For each file saved to disk, have an accompying info file

Currently, when we save files to disk and then attempt to local-load them later it's actually an annoying experience.
* You have to work out the data type to use by hand and specify it
* You don't get URL's in the database
* You might have to work out the encoding and specify it

This P.R. dumps all the information needed to fill the above gaps to files on disk along side the data.

The idea is that we would leave local-load alone (because there might be a use case for loading some files a publisher emails us or something) but add a new command to process, called "load-scrape-files" or something. You would simply pass the directory that has the data you want to load, and the command would be able to load all the other information it needs from the info files in that directory!