### PR TITLE
Add proxy options for Paraguay spiders

### DIFF
--- a/docs/use-hosted.rst
+++ b/docs/use-hosted.rst
@@ -37,6 +37,18 @@ To start a run using 'sample mode', to obtain a small amount of data quickly:
 
 Update the note with your name, and anything else of interest.
 
+Scheduling a Run using a proxy
+------------------------------
+
+Some spiders can be run with the use of a proxy. To do this, use the commands above but add the the https_proxy and http_proxy options.
+
+.. code-block:: bash
+
+    $ ... -d https_proxy=URL -d http_proxy=URL
+
+Note only some spiders will make use of a proxy. Other spiders will silently ignore these options.
+
+
 Run Status & Logs
 -----------------
 

--- a/kingfisher_scrapy/middlewares.py
+++ b/kingfisher_scrapy/middlewares.py
@@ -4,6 +4,24 @@ from datetime import datetime
 from kingfisher_scrapy.exceptions import AuthenticationFailureException
 
 
+class HttpProxyWithSpiderArgsMiddleware(object):
+
+    def __init__(self, spider):
+        logging.info('Using HttpProxyWithSpiderArgsMiddleware.')
+        if not hasattr(spider, 'http_proxy') and not hasattr(spider, 'https_proxy'):
+            logging.warning('No proxy arguments have been set!')
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler.spider)
+
+    def process_request(self, request, spider):
+        if request.url.startswith('https:') and hasattr(spider, 'https_proxy'):
+            request.meta['proxy'] = spider.https_proxy
+        elif request.url.startswith('http:') and hasattr(spider, 'http_proxy'):
+            request.meta['proxy'] = spider.http_proxy
+
+
 class ParaguayAuthMiddleware(object):
     """Downloader middleware that manages API authentication for Paraguay
     scrapers.


### PR DESCRIPTION
I made these changes so the Paraguay DNCP spiders can take 2 arguments as proxy setttings:

* http_proxy
* https_proxy

At the moment, both are needed (token requests are done over https, data requests over http).

Ideally this should be aligned with #197, so I'm leaving this here and when a #197 is merged and there is a https proxy available, I'll remove unnecesary/conflicting code from this solution.