### PR TITLE
requirements: Run pip-tools to upgrade all

### DIFF
--- a/kingfisher_scrapy/spiders/dominican_republic.py
+++ b/kingfisher_scrapy/spiders/dominican_republic.py
@@ -1,8 +1,8 @@
 import os
 import tempfile
 
-import scrapy
 import rarfile
+import scrapy
 
 from kingfisher_scrapy.base_spider import BaseSpider
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,36 +5,36 @@
 #    pip-compile
 #
 attrs==19.3.0             # via automat, service-identity, twisted
-automat==0.8.0            # via twisted
+automat==20.2.0           # via twisted
 certifi==2019.11.28       # via requests
-cffi==1.13.2              # via cryptography
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 constantly==15.1.0        # via twisted
 cryptography==2.8         # via pyopenssl, scrapy, service-identity
 cssselect==1.1.0          # via parsel, scrapy
 hyperlink==19.0.0         # via twisted
-idna==2.8                 # via hyperlink, requests
+idna==2.9                 # via hyperlink, requests
 incremental==17.5.0       # via twisted
-lxml==4.4.2               # via parsel, scrapy
+lxml==4.5.0               # via parsel, scrapy
 parsel==1.5.2             # via scrapy
 protego==0.1.16           # via scrapy
-pyasn1-modules==0.2.7     # via service-identity
+pyasn1-modules==0.2.8     # via service-identity
 pyasn1==0.4.8             # via pyasn1-modules, service-identity
-pycparser==2.19           # via cffi
+pycparser==2.20           # via cffi
 pydispatcher==2.0.5       # via scrapy
-pyhamcrest==1.9.0         # via twisted
+pyhamcrest==2.0.2         # via twisted
 pyopenssl==19.1.0         # via scrapy
 queuelib==1.5.0           # via scrapy
 rarfile==3.1              # via -r requirements.in
-requests==2.22.0          # via -r requirements.in
-scrapy==1.8.0             # via -r requirements.in
+requests==2.23.0          # via -r requirements.in
+scrapy==2.0.1             # via -r requirements.in, scrapyd-client
 scrapyd-client==1.1.0     # via -r requirements.in
 service-identity==18.1.0  # via scrapy
-six==1.13.0               # via automat, cryptography, parsel, protego, pyhamcrest, pyopenssl, scrapy, scrapyd-client, w3lib
-twisted==19.10.0          # via scrapy
-urllib3==1.25.7           # via requests
+six==1.14.0               # via automat, cryptography, parsel, protego, pyopenssl, scrapyd-client, w3lib
+twisted==20.3.0           # via scrapy
+urllib3==1.25.8           # via requests
 w3lib==1.21.0             # via parsel, scrapy
-zope.interface==4.7.1     # via scrapy, twisted
+zope.interface==5.0.2     # via scrapy, twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,55 +4,56 @@
 #
 #    pip-compile requirements_dev.in
 #
-attrs==19.3.0
-automat==0.8.0
-certifi==2019.11.28
-cffi==1.13.2
-chardet==3.0.4
-click==7.0                # via pip-tools
-constantly==15.1.0
-coverage==5.0.3
-cryptography==2.8
-cssselect==1.1.0
+attrs==19.3.0             # via -r requirements.txt, automat, pytest, service-identity, twisted
+automat==20.2.0           # via -r requirements.txt, twisted
+certifi==2019.11.28       # via -r requirements.txt, requests
+cffi==1.14.0              # via -r requirements.txt, cryptography
+chardet==3.0.4            # via -r requirements.txt, requests
+click==7.1.1              # via pip-tools
+constantly==15.1.0        # via -r requirements.txt, twisted
+coverage==5.0.4           # via -r requirements_dev.in, pytest-cov
+cryptography==2.8         # via -r requirements.txt, pyopenssl, scrapy, service-identity
+cssselect==1.1.0          # via -r requirements.txt, parsel, scrapy
 entrypoints==0.3          # via flake8
-flake8==3.7.9
-hyperlink==19.0.0
-idna==2.8
-importlib-metadata==1.3.0  # via pluggy, pytest
-incremental==17.5.0
-isort==4.3.21
-lxml==4.4.2
+flake8==3.7.9             # via -r requirements_dev.in
+hyperlink==19.0.0         # via -r requirements.txt, twisted
+idna==2.9                 # via -r requirements.txt, hyperlink, requests
+importlib-metadata==1.6.0  # via pluggy, pytest
+incremental==17.5.0       # via -r requirements.txt, twisted
+isort==4.3.21             # via -r requirements_dev.in
+lxml==4.5.0               # via -r requirements.txt, parsel, scrapy
 mccabe==0.6.1             # via flake8
-more-itertools==8.0.2     # via pytest, zipp
-packaging==19.2           # via pytest
-parsel==1.5.2
-pip-tools==4.3.0
+more-itertools==8.2.0     # via pytest
+packaging==20.3           # via pytest
+parsel==1.5.2             # via -r requirements.txt, scrapy
+pip-tools==4.5.1          # via -r requirements_dev.in
 pluggy==0.13.1            # via pytest
-protego==0.1.16
-py==1.8.0                 # via pytest
-pyasn1-modules==0.2.7
-pyasn1==0.4.8
+protego==0.1.16           # via -r requirements.txt, scrapy
+py==1.8.1                 # via pytest
+pyasn1-modules==0.2.8     # via -r requirements.txt, service-identity
+pyasn1==0.4.8             # via -r requirements.txt, pyasn1-modules, service-identity
 pycodestyle==2.5.0        # via flake8
-pycparser==2.19
-pydispatcher==2.0.5
+pycparser==2.20           # via -r requirements.txt, cffi
+pydispatcher==2.0.5       # via -r requirements.txt, scrapy
 pyflakes==2.1.1           # via flake8
-pyhamcrest==1.9.0
-pyopenssl==19.1.0
-pyparsing==2.4.5          # via packaging
-pytest-cov==2.8.1
-pytest==5.3.2
-queuelib==1.5.0
-requests==2.22.0
-scrapy==1.8.0
-scrapyd-client==1.1.0
-service-identity==18.1.0
-six==1.13.0
-twisted==19.10.0
-urllib3==1.25.7
-w3lib==1.21.0
-wcwidth==0.1.7            # via pytest
-zipp==0.6.0               # via importlib-metadata
-zope.interface==4.7.1
+pyhamcrest==2.0.2         # via -r requirements.txt, twisted
+pyopenssl==19.1.0         # via -r requirements.txt, scrapy
+pyparsing==2.4.6          # via packaging
+pytest-cov==2.8.1         # via -r requirements_dev.in
+pytest==5.4.1             # via -r requirements_dev.in, pytest-cov
+queuelib==1.5.0           # via -r requirements.txt, scrapy
+rarfile==3.1              # via -r requirements.txt
+requests==2.23.0          # via -r requirements.txt
+scrapy==2.0.1             # via -r requirements.txt, scrapyd-client
+scrapyd-client==1.1.0     # via -r requirements.txt
+service-identity==18.1.0  # via -r requirements.txt, scrapy
+six==1.14.0               # via -r requirements.txt, automat, cryptography, packaging, parsel, pip-tools, protego, pyopenssl, scrapyd-client, w3lib
+twisted==20.3.0           # via -r requirements.txt, scrapy
+urllib3==1.25.8           # via -r requirements.txt, requests
+w3lib==1.21.0             # via -r requirements.txt, parsel, scrapy
+wcwidth==0.1.9            # via pytest
+zipp==3.1.0               # via importlib-metadata
+zope.interface==5.0.2     # via -r requirements.txt, scrapy, twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This
* adds rarfile to dev locked dependencies
* upgrades pip-tools to a version that works with the latest version of pip
* fixes Twisted security alert