### PR TITLE
Remove HttpProxyWithSpiderArgsMiddleware

### DIFF
--- a/docs/local.rst
+++ b/docs/local.rst
@@ -58,6 +58,11 @@ To run a spider (that is, to start a "crawl"), replace ``spider_name`` below wit
 
     scrapy crawl spider_name
 
+.. _sample:
+
+Download a sample
+~~~~~~~~~~~~~~~~~
+
 To download only a sample of the available data, add the ``sample=true`` spider argument:
 
 .. code-block:: bash
@@ -68,8 +73,8 @@ Scrapy will then output a log of its activity.
 
 .. _proxy:
 
-Using an HTTP proxy
-~~~~~~~~~~~~~~~~~~~
+Use a proxy
+~~~~~~~~~~~
 
 .. note::
 
@@ -77,11 +82,11 @@ Using an HTTP proxy
 
 If the data source is blocking Scrapy's requests, you might need to use a proxy.
 
-To use an HTTP and/or HTTPS proxy, add the ``http_proxy`` and/or ``https_proxy`` spider arguments:
+To use an HTTP and/or HTTPS proxy, set the ``http_proxy`` and/or ``https_proxy`` environment variables, and `override <https://docs.scrapy.org/en/latest/topics/settings.html#command-line-options>`__ the ``HTTPPROXY_ENABLED`` Scrapy setting:
 
 .. code-block:: bash
 
-    scrapy crawl spider_name -a http_proxy=YOUR-PROXY-URL -a https_proxy=YOUR-PROXY-URL
+    env http_proxy=YOUR-PROXY-URL https_proxy=YOUR-PROXY-URL scrapy crawl spider_name -s HTTPPROXY_ENABLED=True
 
 Use data
 --------

--- a/docs/scrapyd.rst
+++ b/docs/scrapyd.rst
@@ -84,8 +84,14 @@ If successful, you'll see something like:
 
     {"status": "ok", "jobid": "6487ec79947edab326d6db28a2d86511e8247444"}
 
-Like when :ref:`downloading data to your computer<collect-data>`, you can download only a sample of the available data or :ref:`use a proxy<proxy>` – just remember to use ``-d`` instead of ``-a`` before each spider argument. For example, replace ``localhost`` with your remote server and ``spider_name`` with a spider's name:
+To :ref:`download only a sample of the available data<sample>`, use ``-d`` instead of ``-a`` before each spider argument. For example, replace ``localhost`` with your remote server and ``spider_name`` with a spider's name:
 
 .. code-block:: bash
 
     curl http://localhost:6800/schedule.json -d project=kingfisher -d spider=spider_name -d sample=true
+
+To :ref:`use an HTTP and/or HTTPS proxy<proxy>`, `use <https://scrapyd.readthedocs.io/en/stable/api.html#schedule-json>`__ ``-d setting=`` instead of ``-s`` before each overridden setting. (The ``http_proxy`` and/or ``https_proxy`` environment variables must already be set in Scrapyd's environment.) For example, replace ``localhost`` with your remote server and ``spider_name`` with a spider's name:
+
+.. code-block:: bash
+
+    curl http://localhost:6800/schedule.json -d project=kingfisher -d spider=spider_name -d setting=HTTPPROXY_ENABLED=True

--- a/kingfisher_scrapy/base_spider.py
+++ b/kingfisher_scrapy/base_spider.py
@@ -20,21 +20,13 @@ class KingfisherSpiderMixin:
     .. code:: bash
 
         scrapy crawl spider_name -a note='Started by NAME.'
-
-    Use a proxy:
-
-    .. code:: bash
-
-       scrapy crawl spider_name -a http_proxy=URL -a https_proxy=URL
     """
-    def __init__(self, sample=None, note=None, http_proxy=None, https_proxy=None, *args, **kwargs):
+    def __init__(self, sample=None, note=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # https://docs.scrapy.org/en/latest/topics/spiders.html#spider-arguments
         self.sample = sample == 'true'
         self.note = note
-        self.http_proxy = http_proxy
-        self.https_proxy = https_proxy
 
     def get_local_file_path_including_filestore(self, filename):
         """

--- a/kingfisher_scrapy/middlewares.py
+++ b/kingfisher_scrapy/middlewares.py
@@ -11,24 +11,6 @@ from datetime import datetime
 import scrapy
 
 
-class HttpProxyWithSpiderArgsMiddleware:
-
-    def __init__(self, spider):
-        logging.info('Using HttpProxyWithSpiderArgsMiddleware.')
-        if not spider.http_proxy and not spider.https_proxy:
-            logging.warning('No proxy arguments have been set!')
-
-    @classmethod
-    def from_crawler(cls, crawler):
-        return cls(crawler.spider)
-
-    def process_request(self, request, spider):
-        if request.url.startswith('https:') and spider.https_proxy:
-            request.meta['proxy'] = spider.https_proxy
-        elif request.url.startswith('http:') and spider.http_proxy:
-            request.meta['proxy'] = spider.http_proxy
-
-
 class ParaguayAuthMiddleware:
     """
     Downloader middleware that manages API authentication for Paraguay scrapers.

--- a/kingfisher_scrapy/middlewares.py
+++ b/kingfisher_scrapy/middlewares.py
@@ -65,7 +65,8 @@ class ParaguayAuthMiddleware:
     @staticmethod
     def _expires_soon(spider):
         # spider MUST implement the expires_soon method
-        return spider.expires_soon(datetime.now() - spider.start_time) if spider.start_time and spider.access_token else True
+        return spider.expires_soon(datetime.now() - spider.start_time) \
+            if spider.start_time and spider.access_token else True
 
 
 class OpenOppsAuthMiddleware:

--- a/kingfisher_scrapy/settings.py
+++ b/kingfisher_scrapy/settings.py
@@ -117,3 +117,6 @@ FILES_STORE = os.getenv('FILES_STORE', 'data')
 
 # https://docs.scrapy.org/en/latest/topics/spider-middleware.html#httperror-allow-all
 HTTPERROR_ALLOW_ALL = True
+
+# https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpproxy-enabled
+HTTPPROXY_ENABLED = False

--- a/kingfisher_scrapy/spiders/paraguay_dncp_base.py
+++ b/kingfisher_scrapy/spiders/paraguay_dncp_base.py
@@ -30,7 +30,6 @@ class ParaguayDNCPBaseSpider(BaseSpider):
 
     custom_settings = {
         'DOWNLOADER_MIDDLEWARES': {
-            'kingfisher_scrapy.middlewares.HttpProxyWithSpiderArgsMiddleware': 350,
             'kingfisher_scrapy.middlewares.ParaguayAuthMiddleware': 543,
         },
         'CONCURRENT_REQUESTS': 1,
@@ -45,10 +44,6 @@ class ParaguayDNCPBaseSpider(BaseSpider):
         if spider.request_token is None:
             logging.error('No request token available')
             raise scrapy.exceptions.CloseSpider('authentication_credentials_missing')
-
-        spider.proxies = None
-        if spider.https_proxy:
-            spider.proxies = {'https': spider.https_proxy}
 
         return spider
 

--- a/kingfisher_scrapy/spiders/paraguay_dncp_base.py
+++ b/kingfisher_scrapy/spiders/paraguay_dncp_base.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import logging
 from datetime import datetime
@@ -88,7 +87,10 @@ class ParaguayDNCPBaseSpider(BaseSpider):
                     self.auth_failed = True
                     raise AuthenticationFailureException()
                 else:
-                    self.logger.info('Requesting access token, attempt {} of {}'.format(attempt + 1, self.max_attempts))
+                    self.logger.info('Requesting access token, attempt {} of {}'.format(
+                        attempt + 1,
+                        self.max_attempts)
+                    )
                     return scrapy.Request(
                         self.auth_url,
                         method='POST',

--- a/kingfisher_scrapy/spiders/paraguay_dncp_records.py
+++ b/kingfisher_scrapy/spiders/paraguay_dncp_records.py
@@ -8,4 +8,3 @@ class ParaguayDNCPRecords(ParaguayDNCPBaseSpider):
     def get_files_to_download(self, content):
         for record in content['records']:
             yield '{}/ocds/record/{}'.format(self.base_url, record['ocid'])
-

--- a/kingfisher_scrapy/spiders/paraguay_hacienda.py
+++ b/kingfisher_scrapy/spiders/paraguay_hacienda.py
@@ -125,7 +125,10 @@ class ParaguayHacienda(BaseSpider):
                     self.auth_failed = True
                     raise AuthenticationFailureException()
                 else:
-                    self.logger.info('Requesting access token, attempt {} of {}'.format(attempt + 1, self.max_attempts))
+                    self.logger.info('Requesting access token, attempt {} of {}'.format(
+                        attempt + 1,
+                        self.max_attempts)
+                    )
                     return scrapy.Request(
                         "https://datos.hacienda.gov.py:443/odmh-api-v1/rest/api/v1/auth/token",
                         method='POST',


### PR DESCRIPTION
closes #296

@aguilerapy Can you test that it uses proxies when running something like this:

```
env http_proxy=YOUR-PROXY-URL https_proxy=YOUR-PROXY-URL scrapy crawl spider_name -s HTTPPROXY_ENABLED=True
```

And that it doesn't use proxies when `-s HTTPPROXY_ENABLED=True` is omitted (even if the environment variables are set)?

I also noticed that `paraguay_dncp_base` sets the priority of `ParaguayAuthMiddleware` to 543 (which is the same value as in the [Scrapy example](https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#activating-a-downloader-middleware)), but it had set the priority of `HttpProxyWithSpiderArgsMiddleware` to 350, whereas Scrapy's `HttpProxyMiddleware` has a priority of 750. Do we need to change the priority of `ParaguayAuthMiddleware`? Here are all the default priorities: https://docs.scrapy.org/en/latest/topics/settings.html#std:setting-DOWNLOADER_MIDDLEWARES_BASE